### PR TITLE
Fix formatting error in example problem beam_3d_exp_gsf.tpd

### DIFF
--- a/examples/mbb_beam/beam_3d_exp_gsf.tpd
+++ b/examples/mbb_beam/beam_3d_exp_gsf.tpd
@@ -22,7 +22,7 @@ LOAD_VALU_Y: -0.5; -1@9; -0.5
 
 NUM_ITER:    50
 
- # Grey-scale filter (GSF)
+# Grey-scale filter (GSF)
 P_FAC      : 1
 P_HOLD     : 15  # num of iters to hold p constant from start
 P_INCR     : 0.2  # increment by this amount


### PR DESCRIPTION
Extra space in front of line 25 was causing example problem to not work. The code would read in the line as input, then fail with the following:

Traceback (most recent call last):
  File "optimise.py", line 21, in <module>
    t.load_tpd_file(argv[1])
  File "/usr/local/lib/python2.7/dist-packages/topy/topology.py", line 82, in load_tpd_file
    self.topydict = tpd_file2dict(fname)
  File "/usr/local/lib/python2.7/dist-packages/topy/parser.py", line 89, in tpd_file2dict
    d = _parsev2007file(s)
  File "/usr/local/lib/python2.7/dist-packages/topy/parser.py", line 123, in _parsev2007file
    d[pair[0].strip()] = pair[1].strip()
IndexError: list index out of range

Removing the space allows the example to run
