### PR TITLE
Apply pep8 codestyle

### DIFF
--- a/topy/elements.py
+++ b/topy/elements.py
@@ -13,15 +13,13 @@ from __future__ import division
 import logging
 from os import path
 
-from numpy import array, linspace, unique, sqrt, round, load
-from numpy.linalg import eigvalsh
+from numpy import load
 
 from .data.matlcons import _a, _nu, _E
 
 logger = logging.getLogger(__name__)
 
-__all__ = ['Q4', 'Q5B',  'Q4a5B',  'Q4T',\
-           'H8', 'H18B', 'H8T']
+__all__ = ['Q4', 'Q5B', 'Q4a5B', 'Q4T', 'H8', 'H18B', 'H8T']
 
 # ===================================================
 # === Messages used for errors, information, etc. ===
@@ -46,7 +44,6 @@ except IOError:
     logger.info('It seems as though all or some of the element stiffness matrices')
     logger.info('do not exist. Creating them...')
     logger.info('This is usually only required once and may take a few minutes.')
-    from topy.data import Q4bar_K
     Q4bar = load(fname)
 
 # ==========================================================================
@@ -56,7 +53,6 @@ fname = path.join(pth, 'Q4.K')
 try:
     Q4 = load(fname)
 except IOError:
-    from topy.data import Q4_K
     Q4 = load(fname)
 
 # =========================================================================
@@ -66,7 +62,6 @@ fname = path.join(pth, 'Q5B.K')
 try:
     Q5B = load(fname)
 except IOError:
-    from topy.data import Q5B_K
     Q5B = load(fname)
 
 # =========================================================
@@ -76,7 +71,6 @@ fname = path.join(pth, 'Q4T.K')
 try:
     Q4T = load(fname)
 except IOError:
-    from topy.data import Q4T_K
     Q4T = load(fname)
 
 # ===========================================================
@@ -88,8 +82,7 @@ except IOError:
 # of characteristic equations of the elemental stiffness matrix is needed.
 # Element thickness set = 1. See De Klerk and Groenwold for details.
 # Symbolic value of alpha_opt for bending:
-alpha2D = (2 * _a**2 * (1 - _nu) * (2 * _nu**2 - _nu + 1)) \
-/ (3 * (_nu + 1) * _E**2)
+alpha2D = (2 * _a**2 * (1 - _nu) * (2 * _nu**2 - _nu + 1)) / (3 * (_nu + 1) * _E**2)
 Q4a5B = Q4 - alpha2D * _E * Q4bar  # stiffness matrix
 
 # 3D elements
@@ -101,7 +94,6 @@ fname = path.join(pth, 'H8.K')
 try:
     H8 = load(fname)
 except IOError:
-    from topy.data import H8_K
     H8 = load(fname)
 
 # ============================================================
@@ -111,7 +103,6 @@ fname = path.join(pth, 'H18B.K')
 try:
     H18B = load(fname)
 except IOError:
-    from topy.data import H18B_K
     H18B = load(fname)
 
 # ==========================================================================
@@ -122,7 +113,6 @@ fname = path.join(pth, 'H8T.K')
 try:
     H8T = load(fname)
 except IOError:
-    from topy.data import H8T_K
     H8T = load(fname)
 
 # EOF elements.py

--- a/topy/optimisation.py
+++ b/topy/optimisation.py
@@ -3,13 +3,13 @@ from os import path, makedirs
 from time import time
 from numpy import array
 
-from .visualisation import *
-from .topology import *
+from .visualisation import create_2d_imag, create_3d_geom
 
 logger = logging.getLogger(__name__)
 
 
 __all__ = ['optimise']
+
 
 def optimise(topology, save=True, dir='./iterations'):
 
@@ -44,23 +44,21 @@ def optimise(topology, save=True, dir='./iterations'):
             if save:
                 create_2d_imag(t.desvars, **params)
 
-        
         str_ = '%4i  | %3.6e | %3.3f | %3.4e | %3.3f | %3.3f |  %1.3f  |  %3.3f '
-        format_ = (t.itercount, t.objfval, t.desvars.mean(),\
-            t.change, t.p, t.q, t.eta.mean(), t.svtfrac)
+        format_ = (t.itercount, t.objfval, t.desvars.mean(),
+                   t.change, t.p, t.q, t.eta.mean(), t.svtfrac)
         logger.info(str_ % format_)
         # Build a list of average etas:
         etas_avg.append(t.eta.mean())
 
-
     # Create (plot) initial design domain:
-    logger.info('\n' + '='*80)
+    logger.info('\n' + '=' * 80)
     # Start optimisation runs, create rest of design domains:
     str_ = '%5s | %11s | %5s | %10s | %5s | %5s | %7s | %5s '
-    format_ = ('Iter', 'Obj. func.  ', 'Vol. ', 'Change    ', \
-        'P_FAC', 'Q_FAC', 'Ave ETA', 'S-V frac.')
+    format_ = ('Iter', 'Obj. func.  ', 'Vol. ', 'Change    ',
+               'P_FAC', 'Q_FAC', 'Ave ETA', 'S-V frac.')
     logger.info(str_ % format_)
-    logger.info('-'*80)
+    logger.info('-' * 80)
     ti = time()
 
     # Try CHG_STOP criteria, if not defined (error), use NUM_ITER for iterations:
@@ -73,14 +71,10 @@ def optimise(topology, save=True, dir='./iterations'):
     te = time()
 
     # Print solid-void ratio info:
-    logger.info('\nSolid plus void to total elements fraction = %3.5f' %\
-        (topology.svtfrac))
+    logger.info('\nSolid plus void to total elements fraction = %3.5f' %
+                (topology.svtfrac))
     # Print iteration info:
-
-    logger.info('%d iterations took %3.3f minutes (%3.3f seconds/iteration)'\
-        %(topology.itercount, (te - ti) / 60, (te - ti) / topology.itercount))
-    logger.info('Average of all ETA\'s = %3.3f (average of all a\'s = %3.3f)' \
-        % (array(etas_avg).mean(), 1/array(etas_avg).mean() - 1))
-
-
-
+    logger.info('%d iterations took %3.3f minutes (%3.3f seconds/iteration)' %
+                (topology.itercount, (te - ti) / 60, (te - ti) / topology.itercount))
+    logger.info('Average of all ETA\'s = %3.3f (average of all a\'s = %3.3f)' %
+                (array(etas_avg).mean(), 1 / array(etas_avg).mean() - 1))

--- a/topy/parser.py
+++ b/topy/parser.py
@@ -11,7 +11,6 @@ from string import lower
 import numpy as np
 from pysparse import spmatrix
 
-from .elements import *
 
 logger = logging.getLogger(__name__)
 
@@ -44,9 +43,9 @@ def tpd_file2dict(fname):
     with open(fname, 'r') as f:
         s = f.read()
     # Check for file version header, and parse:
-    if s.startswith('[ToPy Problem Definition File v2007]') != True:
+    if s.startswith('[ToPy Problem Definition File v2007]') is not True:
         raise Exception('Input file or format not recognised')
-    elif s.startswith('[ToPy Problem Definition File v2007]') == True:
+    elif s.startswith('[ToPy Problem Definition File v2007]') is True:
         d = _parsev2007file(s)
         logger.info('ToPy problem definition (TPD) file successfully parsed.')
         logger.info('TPD file name: {} (v2007)\n'.format(fname))
@@ -93,19 +92,17 @@ def _parsev2007file(s):
 
     """
     snew = s.splitlines()[1:]
-    snew = [line.split('#')[0] for line in snew] # Get rid of all comments
+    snew = [line.split('#')[0] for line in snew]  # Get rid of all comments
     snew = [line.replace('\t', '') for line in snew]
     snew = [line.replace(' ', '') for line in snew]
     snew = filter(len, snew)
 
-    d = dict([line.split(':') for line in snew]) 
+    d = dict([line.split(':') for line in snew])
     return _parse_dict(d)
 
 
- 
-
 def _parse_dict(d):
-       # Read/convert minimum required input and convert, else exit:
+    # Read/convert minimum required input and convert, else exit:
     d = d.copy()
     try:
         d['PROB_TYPE'] = lower(d['PROB_TYPE'])
@@ -206,16 +203,17 @@ def _parse_dict(d):
     z = d.get('LOAD_VALU_Z_OUT', '')
     d['LOAD_VAL_OUT'] = _valvec(x, y, z)
 
-
     # The following entries are created and added to the dictionary,
     # they are not specified in the ToPy problem definition file:
-    Ksize = d['DOF_PN'] * (d['NUM_ELEM_X'] + 1) * (d['NUM_ELEM_Y'] + 1) * \
-    (d['NUM_ELEM_Z'] + 1) #  Memory allocation hint for PySparse
-    d['K'] = spmatrix.ll_mat_sym(Ksize, Ksize) #  Global stiffness matrix
-    d['E2SDOFMAPI'] =  _e2sdofmapinit(d['NUM_ELEM_X'], d['NUM_ELEM_Y'], \
-    d['DOF_PN']) #  Initial element to structure DOF mapping
-
+    Ksize = (d['DOF_PN'] *
+             (d['NUM_ELEM_X'] + 1) *
+             (d['NUM_ELEM_Y'] + 1) *
+             (d['NUM_ELEM_Z'] + 1))  # Memory allocation hint for PySparse
+    d['K'] = spmatrix.ll_mat_sym(Ksize, Ksize)  # Global stiffness matrix
+    d['E2SDOFMAPI'] = _e2sdofmapinit(d['NUM_ELEM_X'], d['NUM_ELEM_Y'],
+                                     d['DOF_PN'])  # Initial element to structure DOF mapping
     return d
+
 
 def _tpd2vec(seq):
     """
@@ -250,6 +248,7 @@ def _tpd2vec(seq):
         finalvec = np.append(finalvec, vec)
     return finalvec
 
+
 def _dofvec(x, y, z, dofpn):
     """
     DOF vector.
@@ -278,6 +277,7 @@ def _dofvec(x, y, z, dofpn):
         dofz = (vec_z - 1) * dofpn + 2
     return np.r_[dofx, dofy, dofz].astype(int)
 
+
 def _valvec(x, y, z):
     """
     Values (e.g., of loads) vector.
@@ -303,6 +303,7 @@ def _valvec(x, y, z):
 
     return np.r_[vec_x, vec_y, vec_z]
 
+
 def _e2sdofmapinit(nelx, nely, dofpn):
     """
     Create the initial element to structure (e2s) DOF mapping (connectivity).
@@ -322,11 +323,11 @@ def _e2sdofmapinit(nelx, nely, dofpn):
         c = np.arange(3 * (nely + 1), 3 * (nely + 1) + 3)
         b = np.arange(3 * (nely + 2), 3 * (nely + 2) + 3)
         h = np.arange(3 * (nelx + 1) * (nely + 1), 3 * (nelx + 1) * (nely + 1) + 3)
-        e = np.arange(3 * ((nelx+1) * (nely+1)+1), 3 * ((nelx+1) * (nely+1)+1) + 3)
-        g = np.arange(3 * ((nelx + 1) * (nely + 1) + (nely + 1)),\
-            3 * ((nelx + 1) * (nely + 1) + (nely + 1)) + 3)
-        f = np.arange(3 * ((nelx + 1) * (nely + 1) + (nely + 2)),\
-            3 * ((nelx + 1) * (nely + 1) + (nely + 2)) + 3)
+        e = np.arange(3 * ((nelx + 1) * (nely + 1) + 1), 3 * ((nelx + 1) * (nely + 1) + 1) + 3)
+        g = np.arange(3 * ((nelx + 1) * (nely + 1) + (nely + 1)),
+                      3 * ((nelx + 1) * (nely + 1) + (nely + 1)) + 3)
+        f = np.arange(3 * ((nelx + 1) * (nely + 1) + (nely + 2)),
+                      3 * ((nelx + 1) * (nely + 1) + (nely + 2)) + 3)
         e2s = np.r_[a, b, c, d, e, f, g, h]
     return e2s
 
@@ -347,8 +348,5 @@ def _checkparams(d):
         if not d.has_key('FXTR_NODE_X') or not d.has_key('FXTR_NODE_Y'):
             logger.info('\n\tToPy warning: Rigid body motion in 2D is possible!\n')
     if d['DOF_PN'] == 3:
-        if not d.has_key('FXTR_NODE_X') or not d.has_key('FXTR_NODE_Y')\
-        or not d.has_key('FXTR_NODE_Z'):
+        if not d.has_key('FXTR_NODE_X') or not d.has_key('FXTR_NODE_Y') or not d.has_key('FXTR_NODE_Z'):
             logger.info('\n\tToPy warning: Rigid body motion in 3D is possible!\n')
-
-# EOF parser.py

--- a/topy/topology.py
+++ b/topy/topology.py
@@ -7,11 +7,10 @@
 # Copyright (C) 2008, 2015, William Hunter.
 # =============================================================================
 """
-from __future__ import division 
+from __future__ import division
 import logging
 from string import lower
 import numpy as np
-import os
 from pysparse import superlu, itsolvers, precon
 from .parser import tpd_file2dict, config2dict
 
@@ -22,12 +21,12 @@ __all__ = ['Topology']
 
 MAX_ITERS = 250
 
-SOLID, VOID = 1.000, 0.001 #  Upper and lower bound value for design variables
-KDATUM = 0.1 #  Reference stiffness value of springs for mechanism synthesis
+SOLID, VOID = 1.000, 0.001  # Upper and lower bound value for design variables
+KDATUM = 0.1  # Reference stiffness value of springs for mechanism synthesis
 
 # Constants for exponential approximation:
-A_LOW = -3 #  Lower restriction on 'a' for exponential approximation
-A_UPP = -1e-5 #  Upper restriction on 'a' for exponential approximation
+A_LOW = -3  # Lower restriction on 'a' for exponential approximation
+A_UPP = -1e-5  # Upper restriction on 'a' for exponential approximation
 
 
 # =======================
@@ -39,19 +38,18 @@ class Topology:
     values. Data is read from an input file (see 'examples' folder).
 
     """
-    def __init__(self, config=None, topydict={}, pcount=0, 
+    def __init__(self, config=None, topydict={}, pcount=0,
                  qcount=0, itercount=0, change=1, svtfrac=None):
-        self.pcount = pcount #  Counter for continuation of p
-        self.qcount = qcount #  Counter for continuation of q for GSF
-        self.itercount = itercount #  Internal counter
+        self.pcount = pcount  # Counter for continuation of p
+        self.qcount = qcount  # Counter for continuation of q for GSF
+        self.itercount = itercount  # Internal counter
         self.change = change
         self.svtfrac = svtfrac
 
         if config:
             self.topydict = config2dict(config.copy())
         else:
-            self.topydict = topydict #  Store tpd file data in dictionary
-
+            self.topydict = topydict  # Store tpd file data in dictionary
 
     # ======================
     # === Public methods ===
@@ -109,27 +107,27 @@ class Topology:
         # a completely defined topology optimisation problem:
         if not self.topydict:
             raise Exception('You must first load a TPD file!')
-        self.probtype = self.topydict['PROB_TYPE'] #  Problem type
-        self.probname = self.topydict.get('PROB_NAME', '') #  Problem name
-        self.volfrac = self.topydict['VOL_FRAC'] #  Volume fraction
-        self.filtrad = self.topydict['FILT_RAD'] #  Filter radius
-        self.p = self.topydict['P_FAC'] #  'Standard' penalisation factor
-        self.dofpn = self.topydict['DOF_PN'] #  DOF per node
-        self.e2sdofmapi = self.topydict['E2SDOFMAPI'] #  Elem to structdof map
-        self.nelx = self.topydict['NUM_ELEM_X'] #  Number of elements in X
-        self.nely = self.topydict['NUM_ELEM_Y'] #  Number of elements in Y
-        self.nelz = self.topydict['NUM_ELEM_Z'] #  Number of elements in Z
-        self.fixdof = self.topydict['FIX_DOF'] #  Fixed dof vector
-        self.loaddof = self.topydict['LOAD_DOF'] #  Loaded dof vector
-        self.loadval = self.topydict['LOAD_VAL'] #  Loaded dof values
-        self.Ke = self.topydict['ELEM_K'] #  Element stiffness matrix
-        self.K = self.topydict['K'] #  Global stiffness matrix
+        self.probtype = self.topydict['PROB_TYPE']  # Problem type
+        self.probname = self.topydict.get('PROB_NAME', '')  # Problem name
+        self.volfrac = self.topydict['VOL_FRAC']  # Volume fraction
+        self.filtrad = self.topydict['FILT_RAD']  # Filter radius
+        self.p = self.topydict['P_FAC']  # 'Standard' penalisation factor
+        self.dofpn = self.topydict['DOF_PN']  # DOF per node
+        self.e2sdofmapi = self.topydict['E2SDOFMAPI']  # Elem to structdof map
+        self.nelx = self.topydict['NUM_ELEM_X']  # Number of elements in X
+        self.nely = self.topydict['NUM_ELEM_Y']  # Number of elements in Y
+        self.nelz = self.topydict['NUM_ELEM_Z']  # Number of elements in Z
+        self.fixdof = self.topydict['FIX_DOF']  # Fixed dof vector
+        self.loaddof = self.topydict['LOAD_DOF']  # Loaded dof vector
+        self.loadval = self.topydict['LOAD_VAL']  # Loaded dof values
+        self.Ke = self.topydict['ELEM_K']  # Element stiffness matrix
+        self.K = self.topydict['K']  # Global stiffness matrix
         if self.nelz:
-            logger.info('Domain discretisation (NUM_ELEM_X x NUM_ELEM_Y x ' + \
-                'NUM_ELEM_Z) = %d x %d x %d' % (self.nelx, self.nely, self.nelz))
+            logger.info('Domain discretisation (NUM_ELEM_X x NUM_ELEM_Y x ' +
+                        'NUM_ELEM_Z) = %d x %d x %d' % (self.nelx, self.nely, self.nelz))
         else:
-            logger.info( 'Domain discretisation (NUM_ELEM_X x NUM_ELEM_Y) = %d x %d'\
-                % (self.nelx, self.nely))
+            logger.info('Domain discretisation (NUM_ELEM_X x NUM_ELEM_Y) = %d x %d' %
+                        (self.nelx, self.nely))
 
         logger.info('Element type (ELEM_K) = {}'.format(self.topydict['ELEM_TYPE']))
         logger.info('Filter radius (FILT_RAD) = {}'.format(self.filtrad))
@@ -137,12 +135,12 @@ class Topology:
         # Check for either one of the following two, will take NUM_ITER if both
         # are specified.
         try:
-            self.numiter = self.topydict['NUM_ITER'] #  Number of iterations
+            self.numiter = self.topydict['NUM_ITER']  # Number of iterations
             logger.info('Number of iterations (NUM_ITER) = %d' % (self.numiter))
         except KeyError:
-            self.chgstop = self.topydict['CHG_STOP'] #  Change stop criteria
-            logger.info('Change stop value (CHG_STOP) = %.3e (%.2f%%)' \
-                % (self.chgstop, self.chgstop * 100))
+            self.chgstop = self.topydict['CHG_STOP']  # Change stop criteria
+            logger.info('Change stop value (CHG_STOP) = %.3e (%.2f%%)' %
+                        (self.chgstop, self.chgstop * 100))
             self.numiter = MAX_ITERS
 
         # All DOF vector and design variables arrays:
@@ -151,31 +149,30 @@ class Topology:
         # per node, not so, Cartesian dimension also plays a role.
         # Thus, the 'if'* below is a hack for this to work, and it does...
         if self.dofpn == 1:
-            if self.nelz == 0: #  *had to this
+            if self.nelz == 0:  # *had to this
                 self.e2sdofmapi = self.e2sdofmapi[0:4]
-                self.alldof = np.arange(self.dofpn * (self.nelx + 1) * \
-                    (self.nely + 1))
+                self.alldof = np.arange(self.dofpn * (self.nelx + 1) * (self.nely + 1))
                 self.desvars = np.zeros((self.nely, self.nelx)) + self.volfrac
             else:
-                self.alldof = np.arange(self.dofpn * (self.nelx + 1) * \
-                    (self.nely + 1) * (self.nelz + 1))
+                self.alldof = np.arange(self.dofpn * (self.nelx + 1) *
+                                        (self.nely + 1) * (self.nelz + 1))
                 self.desvars = np.zeros((self.nelz, self.nely, self.nelx)) + \
                     self.volfrac
         elif self.dofpn == 2:
             self.alldof = np.arange(self.dofpn * (self.nelx + 1) * (self.nely + 1))
             self.desvars = np.zeros((self.nely, self.nelx)) + self.volfrac
         else:
-            self.alldof = np.arange(self.dofpn * (self.nelx + 1) *\
-                (self.nely + 1) * (self.nelz + 1))
+            self.alldof = np.arange(self.dofpn * (self.nelx + 1) *
+                                    (self.nely + 1) * (self.nelz + 1))
             self.desvars = np.zeros((self.nelz, self.nely, self.nelx)) + \
                 self.volfrac
-        self.df = np.zeros_like(self.desvars) #  Derivatives of obj. func. (array)
-        self.freedof = np.setdiff1d(self.alldof, self.fixdof) #  Free DOF vector
-        self.r = np.zeros_like(self.alldof).astype(float) #  Load vector
-        self.r[self.loaddof] = self.loadval #  Assign load values at loaded dof
-        self.rfree = self.r[self.freedof] #  Modified load vector (free dof)
-        self.d = np.zeros_like(self.r) #  Displacement vector
-        self.dfree = np.zeros_like(self.rfree) #  Modified load vector (free dof)
+        self.df = np.zeros_like(self.desvars)  # Derivatives of obj. func. (array)
+        self.freedof = np.setdiff1d(self.alldof, self.fixdof)  # Free DOF vector
+        self.r = np.zeros_like(self.alldof).astype(float)  # Load vector
+        self.r[self.loaddof] = self.loadval  # Assign load values at loaded dof
+        self.rfree = self.r[self.freedof]  # Modified load vector (free dof)
+        self.d = np.zeros_like(self.r)  # Displacement vector
+        self.dfree = np.zeros_like(self.rfree)  # Modified load vector (free dof)
         # Determine which rows and columns must be deleted from global K:
         self._rcfixed = np.where(np.in1d(self.alldof, self.fixdof), 0, 1)
 
@@ -199,13 +196,12 @@ class Topology:
         self._qincr = self.topydict.get('Q_INCR')
         self._qcon = self.topydict.get('Q_CON', self.numiter)
 
-
         # (3) Exponential approximation of eta:
         if self.topydict['ETA'] == 'exp':
-            #  Initial value of exponent for comp and heat problems:
+            # Initial value of exponent for comp and heat problems:
             self.a = - np.ones(self.desvars.shape)
             if self.probtype == 'mech':
-                #  Initial value of exponent for mech problems:
+                # Initial value of exponent for mech problems:
                 self.a = self.a * 7 / 3
             self.eta = 1 / (1 - self.a)
             logger.info('Damping factor (ETA) = exp')
@@ -234,8 +230,7 @@ class Topology:
 
         # Set parameters for compliant mechanism synthesis, if they exist:
         if self.probtype == 'mech':
-            if self.topydict['LOAD_DOF_OUT'].any() and \
-            self.topydict['LOAD_VAL_OUT'].any():
+            if self.topydict['LOAD_DOF_OUT'].any() and self.topydict['LOAD_VAL_OUT'].any():
                 self.loaddofout = self.topydict['LOAD_DOF_OUT']
                 self.loadvalout = self.topydict['LOAD_VAL_OUT']
             else:
@@ -279,17 +274,16 @@ class Topology:
 
         Kfree = self._updateK(self.K.copy())
 
-        if self.dofpn < 3 and self.nelz == 0: #  Direct solver
-            Kfree = Kfree.to_csr() #  Need CSR for SuperLU factorisation
+        if self.dofpn < 3 and self.nelz == 0:  # Direct solver
+            Kfree = Kfree.to_csr()  # Need CSR for SuperLU factorisation
             lu = superlu.factorize(Kfree)
             lu.solve(self.rfree, self.dfree)
             if self.probtype == 'mech':
                 lu.solve(self.rfreeout, self.dfreeout)  # mechanism synthesis
-        else: #  Iterative solver for 3D problems
+        else:  # Iterative solver for 3D problems
             Kfree = Kfree.to_sss()
-            preK = precon.ssor(Kfree) #  Preconditioned Kfree
-            (info, numitr, relerr) = \
-            itsolvers.pcg(Kfree, self.rfree, self.dfree, 1e-8, 8000, preK)
+            preK = precon.ssor(Kfree)  # Preconditioned Kfree
+            (info, numitr, relerr) = itsolvers.pcg(Kfree, self.rfree, self.dfree, 1e-8, 8000, preK)
             if info < 0:
                 logger.error('PySparse error: Type: {}, '
                              'at {} iterations'.format(info, numitr))
@@ -298,9 +292,7 @@ class Topology:
                 logger.debug('ToPy: Solution for FEA converged after '
                              '{} iterations'.format(numitr))
             if self.probtype == 'mech':  # mechanism synthesis
-                (info, numitr, relerr) = \
-                itsolvers.pcg(Kfree, self.rfreeout, self.dfreeout, 1e-8, \
-                    8000, preK)
+                (info, numitr, relerr) = itsolvers.pcg(Kfree, self.rfreeout, self.dfreeout, 1e-8, 8000, preK)
                 if info < 0:
                     logger.error('PySparse error: Type: {}, '
                                  'at {} iterations'.format(info, numitr))
@@ -340,39 +332,32 @@ class Topology:
                     u = U[umin: umax, vmin: vmax]
                     v = V[umin: umax, vmin: vmax]
                     dist = self.filtrad - np.sqrt((i - u) ** 2 + (j - v) ** 2)
-                    sumnumr = (np.maximum(0, dist) * self.desvars[v, u] *\
-                               self.df[v, u]).sum()
+                    sumnumr = (np.maximum(0, dist) * self.desvars[v, u] * self.df[v, u]).sum()
                     sumconv = np.maximum(0, dist).sum()
                     tmp[j, i] = sumnumr / (sumconv * self.desvars[j, i])
         else:
             rmin3 = rmin
             U, V, W = np.indices((self.nelx, self.nely, self.nelz))
             for i in xrange(self.nelx):
-                umin, umax = np.maximum(i - rmin - 1, 0),\
-                             np.minimum(i + rmin + 2, self.nelx + 1)
+                umin, umax = np.maximum(i - rmin - 1, 0), np.minimum(i + rmin + 2, self.nelx + 1)
                 for j in xrange(self.nely):
-                    vmin, vmax = np.maximum(j - rmin - 1, 0),\
-                                 np.minimum(j + rmin + 2, self.nely + 1)
+                    vmin, vmax = np.maximum(j - rmin - 1, 0), np.minimum(j + rmin + 2, self.nely + 1)
                     for k in xrange(self.nelz):
-                        wmin, wmax = np.maximum(k - rmin3 - 1, 0),\
-                                     np.minimum(k + rmin3 + 2, self.nelz + 1)
+                        wmin, wmax = np.maximum(k - rmin3 - 1, 0), np.minimum(k + rmin3 + 2, self.nelz + 1)
                         u = U[umin:umax, vmin:vmax, wmin:wmax]
                         v = V[umin:umax, vmin:vmax, wmin:wmax]
                         w = W[umin:umax, vmin:vmax, wmin:wmax]
-                        dist = self.filtrad - np.sqrt((i - u) ** 2 + (j - v) **\
-                               2 + (k - w) ** 2)
-                        sumnumr = (np.maximum(0, dist) * self.desvars[w, v, u] *\
-                                  self.df[w, v, u]).sum()
+                        dist = self.filtrad - np.sqrt((i - u) ** 2 + (j - v) ** 2 + (k - w) ** 2)
+                        sumnumr = (np.maximum(0, dist) * self.desvars[w, v, u] * self.df[w, v, u]).sum()
                         sumconv = np.maximum(0, dist).sum()
-                        tmp[k, j, i] = sumnumr/(sumconv *\
-                        self.desvars[k, j, i])
+                        tmp[k, j, i] = sumnumr / (sumconv * self.desvars[k, j, i])
 
         self.df = tmp
 
     def sens_analysis(self):
         """
         Determine the objective function value and perform sensitivity analysis
-        (find the derivatives of objective function). 
+        (find the derivatives of objective function).
 
         EXAMPLES:
             >>> t.sens_analysis()
@@ -383,31 +368,31 @@ class Topology:
         if not self.topydict:
             raise Exception('You must first load a TPD file!')
         tmp = self.df.copy()
-        self.objfval  = 0.0 #  Objective function value
-        
+        self.objfval = 0.0  # Objective function value
+
         # Prepare Supporting Variables
-        if self.nelz == 0: #  2D problem
-    
+        if self.nelz == 0:  # 2D problem
+
             Y, X = np.indices((self.nely, self.nelx))
-            e2sdofmap = np.expand_dims(self.e2sdofmapi.reshape(-1,1), axis=1)
+            e2sdofmap = np.expand_dims(self.e2sdofmapi.reshape(-1, 1), axis=1)
             e2sdofmap = np.add(e2sdofmap, self.dofpn * (Y + X * (self.nely + 1)))
             Qe = self.d[e2sdofmap]
-            QeK = np.tensordot(Qe, self.Ke, axes=(0,0))
+            QeK = np.tensordot(Qe, self.Ke, axes=(0, 0))
             Qe_T = np.swapaxes(Qe, 2, 1).T
             QeKQe = np.einsum('mnk,mnk->mn', QeK, Qe_T)
-            
-        else: #  3D problem
-            
+
+        else:  # 3D problem
+
             Z, Y, X = np.indices((self.nelz, self.nely, self.nelx))
             X *= (self.nely + 1)
             Z *= (self.nelx + 1) * (self.nely + 1)
             e2sdofmap = np.expand_dims(self.e2sdofmapi.reshape(-1, 1, 1), axis=1)
             e2sdofmap = np.add(e2sdofmap, self.dofpn * (X + Y + Z))
             Qe = self.d[e2sdofmap]
-            QeK = np.tensordot(Qe, self.Ke, axes=(0,0))
+            QeK = np.tensordot(Qe, self.Ke, axes=(0, 0))
             Qe_T = np.swapaxes(Qe.T, 2, 0)
             QeKQe = np.einsum('klmn,klmn->klm', QeK, Qe_T)
-        
+
         # Update TMP
         if self.probtype == 'comp':
             self.objfval += ((self.desvars ** self.p) * QeKQe).sum()
@@ -422,7 +407,7 @@ class Topology:
         elif self.probtype == 'mech':
             self.objfval = self.d[self.loaddofout].sum()
             tmp = self.p * self.desvars ** (self.p - 1)
-            
+
             if self.nelz == 0:
                 QeOut_T = np.swapaxes(self.dout[e2sdofmap], 2, 1).T
                 op = np.einsum('mnk,mnk->mn', QeK, QeOut_T)
@@ -430,10 +415,8 @@ class Topology:
                 QeOut_T = np.swapaxes(self.dout[e2sdofmap].T, 2, 0)
                 op = np.einsum('klmn,klmn->klm', QeK, QeOut_T)
             tmp *= op
-            
-            
-        self.df = tmp
 
+        self.df = tmp
 
     def update_desvars_oc(self):
         """
@@ -468,11 +451,11 @@ class Topology:
 
         # Exponential approximation of eta (damping factor):
         if self.itercount > 1:
-            if self.topydict['ETA'] == 'exp': #  Check TPD specified value
+            if self.topydict['ETA'] == 'exp':  # Check TPD specified value
                 mask = np.equal(self.desvarsold / self.desvars, 1)
-                self.a = 1 + np.log2(np.abs(self.dfold / self.df)) / \
-                np.log2(self.desvarsold / self.desvars + mask) + \
-                mask * (self.a - 1)
+                self.a = 1 + (np.log2(np.abs(self.dfold / self.df)) /
+                              np.log2(self.desvarsold / self.desvars + mask) +
+                              mask * (self.a - 1))
                 self.a = np.clip(self.a, A_LOW, A_UPP)
                 self.eta = 1 / (1 - self.a)
 
@@ -491,29 +474,33 @@ class Topology:
             if self.probtype == 'mech':
                 if self.approx == 'dquad':
                     curv = - 1 / (self.eta * self.desvars) * self.df
-                    beta = np.maximum(self.desvars-(self.df + lammid)/curv, VOID)
+                    beta = np.maximum(self.desvars - (self.df + lammid) / curv, VOID)
                     move_upper = np.minimum(move, self.desvars / 3)
-                    desvars = np.maximum(VOID, np.maximum((self.desvars - move),\
-                    np.minimum(SOLID,  np.minimum((self.desvars + move), \
-                    (self.desvars * np.maximum(1e-10, \
-                    (-self.df / lammid))**self.eta)**self.q))))
+                    desvars = np.maximum(VOID,
+                                         np.maximum((self.desvars - move),
+                                                    np.minimum(SOLID,
+                                                               np.minimum((self.desvars + move), (
+                                                                   self.desvars * np.maximum(1e-10, (-self.df / lammid)) ** self.eta) ** self.q))))
                 else:  # reciprocal or exponential
-                    desvars = np.maximum(VOID, np.maximum((self.desvars - move),\
-                    np.minimum(SOLID,  np.minimum((self.desvars + move), \
-                    (self.desvars * np.maximum(1e-10, \
-                    (-self.df / lammid))**self.eta)**self.q))))
+                    desvars = np.maximum(VOID,
+                                         np.maximum((self.desvars - move),
+                                                    np.minimum(SOLID,
+                                                               np.minimum((self.desvars + move), (
+                                                                   self.desvars * np.maximum(1e-10, (-self.df / lammid)) ** self.eta) ** self.q))))
             else:  # compliance or heat
                 if self.approx == 'dquad':
                     curv = - 1 / (self.eta * self.desvars) * self.df
-                    beta = np.maximum(self.desvars-(self.df + lammid)/curv, VOID)
+                    beta = np.maximum(self.desvars - (self.df + lammid) / curv, VOID)
                     move_upper = np.minimum(move, self.desvars / 3)
-                    desvars = np.maximum(VOID, np.maximum((self.desvars - move),\
-                    np.minimum(SOLID,  np.minimum((self.desvars + move_upper), \
-                    beta**self.q))))
+                    desvars = np.maximum(VOID,
+                                         np.maximum((self.desvars - move),
+                                                    np.minimum(SOLID, np.minimum((self.desvars + move_upper), beta ** self.q))))
                 else:  # reciprocal or exponential
-                    desvars = np.maximum(VOID, np.maximum((self.desvars - move),\
-                    np.minimum(SOLID,  np.minimum((self.desvars + move), \
-                    (self.desvars * (-self.df / lammid)**self.eta)**self.q))))
+                    desvars = np.maximum(VOID,
+                                         np.maximum((self.desvars - move),
+                                                    np.minimum(SOLID,
+                                                               np.minimum((self.desvars + move),
+                                                                          (self.desvars * (-self.df / lammid) ** self.eta) ** self.q))))
 
             # Check for passive and active elements, modify updated x:
             if self.pasv.any() or self.actv.any():
@@ -523,19 +510,19 @@ class Topology:
                     y, x = dims
                     for j in range(x):
                         for k in range(y):
-                            idx.append(k*x + j)
+                            idx.append(k * x + j)
                 else:
                     z, y, x = dims
                     for i in range(z):
                         for j in range(x):
                             for k in range(y):
-                                idx.append(k*x + j + i*x*y)
+                                idx.append(k * x + j + i * x * y)
                 if self.pasv.any():
-                    pasv = np.take(idx, self.pasv) #  new indices
-                    np.put(flatx, pasv, VOID) #  = zero density
+                    pasv = np.take(idx, self.pasv)  # new indices
+                    np.put(flatx, pasv, VOID)  # = zero density
                 if self.actv.any():
-                    actv = np.take(idx, self.actv) #  new indices
-                    np.put(flatx, actv, SOLID) #  = solid
+                    actv = np.take(idx, self.actv)  # new indices
+                    np.put(flatx, actv, SOLID)  # = solid
                 desvars = flatx.reshape(dims)
 
             if self.nelz == 0:
@@ -544,8 +531,7 @@ class Topology:
                 else:
                     lam2 = lammid
             else:
-                if desvars.sum() - self.nelx * self.nely * self.nelz *\
-                self.volfrac > 0:
+                if desvars.sum() - self.nelx * self.nely * self.nelz * self.volfrac > 0:
                     lam1 = lammid
                 else:
                     lam2 = lammid
@@ -571,36 +557,28 @@ class Topology:
         Return unconstrained stiffness matrix.
 
         """
-        if self.nelz == 0: #  2D problem
+        if self.nelz == 0:  # 2D problem
             for elx in xrange(self.nelx):
                 for ely in xrange(self.nely):
-                    e2sdofmap = self.e2sdofmapi + self.dofpn *\
-                    (ely + elx * (self.nely + 1))
+                    e2sdofmap = self.e2sdofmapi + self.dofpn * (ely + elx * (self.nely + 1))
                     if self.probtype == 'comp' or self.probtype == 'mech':
                         updatedKe = self.desvars[ely, elx] ** self.p * self.Ke
                     elif self.probtype == 'heat':
-                        updatedKe = (VOID + (1 - VOID) * \
-                        self.desvars[ely, elx] ** self.p) * self.Ke
+                        updatedKe = (VOID + (1 - VOID) * self.desvars[ely, elx] ** self.p) * self.Ke
                     mask = np.ones(e2sdofmap.size, dtype=int)
                     K.update_add_mask_sym(updatedKe, e2sdofmap, mask)
-        else: #  3D problem
+        else:  # 3D problem
             for elz in xrange(self.nelz):
                 for elx in xrange(self.nelx):
                     for ely in xrange(self.nely):
-                        e2sdofmap = self.e2sdofmapi + self.dofpn *\
-                                    (ely + elx * (self.nely + 1) + elz *\
-                                    (self.nelx + 1) * (self.nely + 1))
+                        e2sdofmap = self.e2sdofmapi + self.dofpn * (ely + elx * (self.nely + 1) + elz * (self.nelx + 1) * (self.nely + 1))
                         if self.probtype == 'comp' or self.probtype == 'mech':
-                            updatedKe = self.desvars[elz, ely, elx] ** \
-                            self.p * self.Ke
+                            updatedKe = self.desvars[elz, ely, elx] ** self.p * self.Ke
                         elif self.probtype == 'heat':
-                            updatedKe = (VOID + (1 - VOID) * \
-                            self.desvars[elz, ely, elx] ** self.p) * self.Ke
+                            updatedKe = (VOID + (1 - VOID) * self.desvars[elz, ely, elx] ** self.p) * self.Ke
                         mask = np.ones(e2sdofmap.size, dtype=int)
                         K.update_add_mask_sym(updatedKe, e2sdofmap, mask)
 
-        K.delete_rowcols(self._rcfixed) #  Del constrained rows and columns
+        K.delete_rowcols(self._rcfixed)  # Del constrained rows and columns
         return K
-
-
 # EOF topology.py

--- a/topy/visualisation.py
+++ b/topy/visualisation.py
@@ -16,7 +16,8 @@ from numpy import arange, asarray, hstack
 from pyvtk import CellData, LookupTable, Scalars, UnstructuredGrid, VtkData
 
 __all__ = ['create_2d_imag', 'create_3d_geom', 'node_nums_2d', 'node_nums_3d',
-'create_2d_msh','create_3d_msh']
+           'create_2d_msh', 'create_3d_msh']
+
 
 def create_2d_imag(x, **kwargs):
     """
@@ -53,7 +54,7 @@ def create_2d_imag(x, **kwargs):
     # === Start of Matplotlib commands ===
     # ====================================
     # x = flipud(x) #  Check your matplotlibrc file; might plot upside-down...
-    figure() # open a figure
+    figure()  # open a figure
     if kwargs.has_key('title'):
         title(kwargs['title'])
         imshow(-x, cmap=cm.gray, aspect='equal', interpolation='nearest')
@@ -71,7 +72,8 @@ def create_2d_imag(x, **kwargs):
     fname = _change_fname(fname_dict, kwargs)
     # Save the domain as image:
     savefig(fname, bbox_inches='tight')
-    close() # close the figure
+    close()  # close the figure
+
 
 def create_3d_geom(x, **kwargs):
     """
@@ -114,6 +116,7 @@ def create_3d_geom(x, **kwargs):
     # Save the domain as geometry:
     _write_geom(x, fname)
 
+
 def create_2d_msh(nelx, nely, fname):
     """
     Create a 2d Gmsh MSH ASCII file by specifying the number of elements in the
@@ -150,7 +153,7 @@ def create_2d_msh(nelx, nely, fname):
         outputfile.write(MSH_header)
         # MSH nodes
         outputfile.write(MSH_nodes[0])
-        outputfile.write(str(nnodes)+'\n')
+        outputfile.write(str(nnodes) + '\n')
         nodenum = 1
         for x in xcoords:
             for y in ycoords:
@@ -160,13 +163,14 @@ def create_2d_msh(nelx, nely, fname):
         outputfile.write(MSH_nodes[1])
         # MSH elements
         outputfile.write(MSH_elements[0])
-        outputfile.write(str(nelms)+'\n')
+        outputfile.write(str(nelms) + '\n')
         # elm-number elm-type number-of-tags < tag > ... node-number-list
         for elem in arange(1, nelms + 1):
-            outputfile.write(str(elem) + ' 3 0 ') # 3 is a 4-node quadrangle
+            outputfile.write(str(elem) + ' 3 0 ')  # 3 is a 4-node quadrangle
             nn = node_nums_2d(nelx, nely, elem)
             outputfile.write(str(nn[0]) + ' ' + str(nn[1]) + ' ' + str(nn[3]) + ' ' + str(nn[2]) + '\n')
         outputfile.write(MSH_elements[1])
+
 
 def create_3d_msh(nelx, nely, nelz, fname):
     """
@@ -217,14 +221,15 @@ def create_3d_msh(nelx, nely, nelz, fname):
         outputfile.write(MSH_nodes[1])
         # MSH elements
         outputfile.write(MSH_elements[0])
-        outputfile.write(str(nelms)+'\n')
+        outputfile.write(str(nelms) + '\n')
         # elm-number elm-type number-of-tags < tag > ... node-number-list
         for elem in arange(1, nelms + 1):
-            outputfile.write(str(elem) + ' 5 0 ') # 5 is a 8-node hexahedron
+            outputfile.write(str(elem) + ' 5 0 ')  # 5 is a 8-node hexahedron
             nn = node_nums_3d(nelx, nely, nelz, elem)
-            outputfile.write(str(nn[0]) + ' ' + str(nn[1]) + ' ' + str(nn[3]) + ' ' + str(nn[2]) + ' ' + \
+            outputfile.write(str(nn[0]) + ' ' + str(nn[1]) + ' ' + str(nn[3]) + ' ' + str(nn[2]) + ' ' +
                              str(nn[4]) + ' ' + str(nn[5]) + ' ' + str(nn[7]) + ' ' + str(nn[6]) + '\n')
         outputfile.write(MSH_elements[1])
+
 
 def node_nums_2d(nelx, nely, en):
     """
@@ -251,9 +256,10 @@ def node_nums_2d(nelx, nely, en):
     """
     if en > nelx * nely:
         raise Exception('Mesh does not contain specified element number.')
-    inn = asarray([0, 1, nely + 1, nely + 2]) #  initial node numbers
-    nn = inn + (en + (en - 1) // nely) #  the element's node numbers
+    inn = asarray([0, 1, nely + 1, nely + 2])  # initial node numbers
+    nn = inn + (en + (en - 1) // nely)  # the element's node numbers
     return nn
+
 
 def node_nums_3d(nelx, nely, nelz, en):
     """
@@ -284,24 +290,24 @@ def node_nums_3d(nelx, nely, nelz, en):
     xygridsize = nelx * nely
     if en > nelx * nely * nelz:
         raise Exception('Mesh does not contain specified element number.')
-    pen = en % (xygridsize) #  projected element number on rearmost face
+    pen = en % (xygridsize)  # projected element number on rearmost face
     if pen == 0:
         pen = xygridsize
 
-    nnzero = node_nums_2d(nelx, nely, pen) #  node numbers at rearmost face
+    nnzero = node_nums_2d(nelx, nely, pen)  # node numbers at rearmost face
     zinc = (en - 1) // xygridsize * (nelx + 1) * (nely + 1)
     nnr = nnzero + zinc
     nnf = nnr + (nelx + 1) * (nely + 1)
-    nn = hstack( (nnr, nnf) )
+    nn = hstack((nnr, nnf))
     return nn
+
 
 # =====================================
 # === Private functions and helpers ===
 # =====================================
 def _change_fname(fd, kwargs):
     # Default file name:
-    filename = fd['dflt_prefix'] + '_' + fd['dflt_iternum'] + \
-    fd['dflt_timestamp'] + '.' + fd['dflt_filetype']
+    filename = fd['dflt_prefix'] + '_' + fd['dflt_iternum'] + fd['dflt_timestamp'] + '.' + fd['dflt_filetype']
 
     # This is not pretty but it works...
     if kwargs.has_key('prefix'):
@@ -316,11 +322,12 @@ def _change_fname(fd, kwargs):
         filename = filename.replace(fd['dflt_timestamp'], '')
     if kwargs.has_key('dir'):
         dir = kwargs['dir']
-        if not  dir[-1] == '/':
+        if not dir[-1] == '/':
             dir = dir + '/'
         filename = dir + filename
 
     return filename
+
 
 def _write_geom(x, fname):
     '''
@@ -332,6 +339,7 @@ def _write_geom(x, fname):
         print 'Other file formats not implemented, only legacy VTK.'
         #_write_vrml2(x, fname) # future
 
+
 def _write_legacy_vtu(x, fname):
     """
     Write a legacy VTK unstructured grid file.
@@ -342,9 +350,16 @@ def _write_legacy_vtu(x, fname):
     THRESHOLD = 0.001
 
     # Voxel local points relative to its centre of geometry:
-    voxel_local_points = asarray([[-1,-1,-1],[ 1,-1,-1],[-1, 1,-1],[ 1, 1,-1],
-                                [-1,-1, 1],[ 1,-1, 1],[-1, 1, 1],[ 1, 1, 1]])\
-                                  * 0.5 # scaling
+    voxel_local_points = asarray([
+        [-1, -1, -1],
+        [1, -1, -1],
+        [-1, 1, -1],
+        [1, 1, -1],
+        [-1, -1, 1],
+        [1, -1, 1],
+        [-1, 1, 1],
+        [1, 1, 1]
+    ]) * 0.5  # scaling
     # Voxel world points:
     points = []
     # Culled input array -- as list:
@@ -358,19 +373,17 @@ def _write_legacy_vtu(x, fname):
     for i in xrange(depth):
         for j in xrange(rows):
             for k in xrange(columns):
-                if x[i,j,k] > THRESHOLD:
-                    xculled.append(x[i,j,k])
-                    points += (voxel_local_points + [i,j,k]).tolist()
+                if x[i, j, k] > THRESHOLD:
+                    xculled.append(x[i, j, k])
+                    points += (voxel_local_points + [i, j, k]).tolist()
 
     voxels = arange(len(points)).reshape(len(xculled), 8).tolist()
-    topology = UnstructuredGrid(points, voxel = voxels)
-    file_header = \
-    'ToPy data, created '\
-    + str(datetime.now()).rsplit('.')[0]
-    scalars = CellData(Scalars(xculled, name='Densities', lookup_table =\
-    'default'))
+    topology = UnstructuredGrid(points, voxel=voxels)
+    file_header = 'ToPy data, created ' + str(datetime.now()).rsplit('.')[0]
+    scalars = CellData(Scalars(xculled, name='Densities', lookup_table='default'))
     vtk = VtkData(topology, file_header, scalars)
     vtk.tofile(fname, 'binary')
+
 
 def _timestamp():
     """
@@ -386,6 +399,7 @@ def _timestamp():
     ts = day + '-' + month + '-' + year + '-' + hour + 'h' + minute
     return ts
 
+
 def _fixstring(s):
     """
     Fix the string by adding a zero in front if single digit number.
@@ -394,6 +408,7 @@ def _fixstring(s):
     if len(s) == 1:
         s = '0' + s
     return s
+
 
 def _fixiternum(s):
     """
@@ -406,5 +421,4 @@ def _fixiternum(s):
     elif len(s) == 1:
         s = '00' + s
     return s
-
 # EOF visualisation.py


### PR DESCRIPTION
This is much more a purpose and an example of what must be done in project codestyle. This pull request apply a bunch of pep8[1] recomendations. It's important to follow this convention so the project would be more readable to new contributors.

Trying to apply pep8 some code improvements can be noted. For example: there's some operations too long that would be better if splitted in more than one instruction as the snippet below:
```python
# bad style
operation = a + b + c * (c + f + j) / (a + b + c) ** 2

# better style
initial_operation = a + b + c
second_operation = initial_operation * (c + f + j)
other_meaning_name_operation = (a + b + c) ** 2
conclution_operation = second_operation / other_meaning_name_operation
```

Other thing. What about migrating the code to Python 3? 👍 