### PR TITLE
Bug and Compatibility Fix

### DIFF
--- a/topy/data/H18B_K.py
+++ b/topy/data/H18B_K.py
@@ -20,12 +20,12 @@ from sympy import symbols, Matrix, diff, integrate, zeros, eye
 from numpy import abs, array, transpose, dot
 from numpy.linalg import inv
 
-from ..utils import get_logger
+from ..utils import get_logger, get_data_file
 from .matlcons import *
 
 logger = get_logger(__name__)
 # Get file name:
-fname = __file__.split('_')[0] + '.K'
+fname = get_data_file(__file__)
 
 if os.path.exists(fname):
     logger.info('{} (stiffness matrix) exists!'.format(fname))

--- a/topy/data/H8T_K.py
+++ b/topy/data/H8T_K.py
@@ -19,12 +19,12 @@ import os
 from sympy import symbols, Matrix, diff, integrate, zeros
 from numpy import abs, array
 
-from ..utils import get_logger
+from ..utils import get_logger, get_data_file
 from .matlcons import *
 
 logger = get_logger(__name__)
 # Get file name:
-fname = __file__.split('_')[0] + '.K'
+fname = get_data_file(__file__)
 
 if os.path.exists(fname):
     logger.info('{} (stiffness matrix) exists!'.format(fname))

--- a/topy/data/H8_K.py
+++ b/topy/data/H8_K.py
@@ -19,12 +19,12 @@ import os
 from sympy import symbols, Matrix, diff, integrate, zeros
 from numpy import abs, array
 
-from ..utils import get_logger
+from ..utils import get_logger, get_data_file
 from .matlcons import *
 
 logger = get_logger(__name__)
 # Get file name:
-fname = __file__.split('_')[0] + '.K'
+fname = get_data_file(__file__)
 
 if os.path.exists(fname):
     logger.info('{} (stiffness matrix) exists!'.format(fname))

--- a/topy/data/H8bar_K.py
+++ b/topy/data/H8bar_K.py
@@ -19,12 +19,12 @@ import os
 from sympy import symbols, Matrix, diff, integrate, zeros
 from numpy import abs, array
 
-from ..utils import get_logger
+from ..utils import get_logger, get_data_file
 from .matlcons import *
 
 logger = get_logger(__name__)
 # Get file name:
-fname = __file__.split('_')[0] + '.K'
+fname = get_data_file(__file__)
 
 if os.path.exists(fname):
     logger.info('{} (stiffness matrix) exists!'.format(fname))

--- a/topy/data/Q4T_K.py
+++ b/topy/data/Q4T_K.py
@@ -19,12 +19,12 @@ import os
 from sympy import symbols, Matrix, diff, integrate, zeros
 from numpy import abs, array
 
-from ..utils import get_logger
+from ..utils import get_logger, get_data_file
 from .matlcons import *
 
 logger = get_logger(__name__)
 # Get file name:
-fname = __file__.split('_')[0] + '.K'
+fname = get_data_file(__file__)
 
 if os.path.exists(fname):
     logger.info('{} (stiffness matrix) exists!'.format(fname))

--- a/topy/data/Q4_K.py
+++ b/topy/data/Q4_K.py
@@ -19,12 +19,12 @@ import os
 from sympy import symbols, Matrix, diff, integrate, zeros
 from numpy import abs, array
 
-from ..utils import get_logger
+from ..utils import get_logger, get_data_file
 from .matlcons import *
 
 logger = get_logger(__name__)
 # Get file name:
-fname = __file__.split('_')[0] + '.K'
+fname = get_data_file(__file__)
 
 if os.path.exists(fname):
     logger.info('{} (stiffness matrix) exists!'.format(fname))

--- a/topy/data/Q4bar_K.py
+++ b/topy/data/Q4bar_K.py
@@ -19,12 +19,12 @@ import os
 from sympy import symbols, Matrix, diff, integrate, zeros
 from numpy import abs, array
 
-from ..utils import get_logger
+from ..utils import get_logger, get_data_file
 from .matlcons import *
 
 logger = get_logger(__name__)
 # Get file name:
-fname = __file__.split('_')[0] + '.K'
+fname = get_data_file(__file__)
 
 if os.path.exists(fname):
     logger.info('{} (stiffness matrix) exists!'.format(fname))

--- a/topy/data/Q5B_K.py
+++ b/topy/data/Q5B_K.py
@@ -19,12 +19,12 @@ import os
 from sympy import symbols, Matrix, diff, integrate, zeros, eye
 from numpy import abs, array
 
-from ..utils import get_logger
+from ..utils import get_logger, get_data_file
 from .matlcons import *
 
 logger = get_logger(__name__)
 # Get file name:
-fname = __file__.split('_')[0] + '.K'
+fname = get_data_file(__file__)
 
 if os.path.exists(fname):
     logger.info('{} (stiffness matrix) exists!'.format(fname))

--- a/topy/elements.py
+++ b/topy/elements.py
@@ -39,43 +39,43 @@ pth = path.join(path.split(__file__)[0], 'data')
 # ==============================================
 fname = path.join(pth, 'Q4bar.K')
 try:
-    Q4bar = load(fname)
+    Q4bar = load(fname, allow_pickle=True)
 except IOError:
     logger.info('It seems as though all or some of the element stiffness matrices')
     logger.info('do not exist. Creating them...')
     logger.info('This is usually only required once and may take a few minutes.')
     from topy.data import Q4bar_K
-    Q4bar = load(fname)
+    Q4bar = load(fname, allow_pickle=True)
 
 # ==========================================================================
 # === Stiffness matrix of a square 4 node plane stress bi-linear element ===
 # ==========================================================================
 fname = path.join(pth, 'Q4.K')
 try:
-    Q4 = load(fname)
+    Q4 = load(fname, allow_pickle=True)
 except IOError:
     from topy.data import Q4_K
-    Q4 = load(fname)
+    Q4 = load(fname, allow_pickle=True)
 
 # =========================================================================
 # === Stiffness matrix of a square 4 node plane stress '5-beta' element ===
 # =========================================================================
 fname = path.join(pth, 'Q5B.K')
 try:
-    Q5B = load(fname)
+    Q5B = load(fname, allow_pickle=True)
 except IOError:
     from topy.data import Q5B_K
-    Q5B = load(fname)
+    Q5B = load(fname, allow_pickle=True)
 
 # =========================================================
 # === Matrix for an element used in 2D thermal problems ===
 # =========================================================
 fname = path.join(pth, 'Q4T.K')
 try:
-    Q4T = load(fname)
+    Q4T = load(fname, allow_pickle=True)
 except IOError:
     from topy.data import Q4T_K
-    Q4T = load(fname)
+    Q4T = load(fname, allow_pickle=True)
 
 # ===========================================================
 # === Stiffness matrix of a square 4 node 'Q4a5B' element ===
@@ -97,20 +97,20 @@ Q4a5B = Q4 - alpha2D * _E * Q4bar  # stiffness matrix
 # ======================================================================
 fname = path.join(pth, 'H8.K')
 try:
-    H8 = load(fname)
+    H8 = load(fname, allow_pickle=True)
 except IOError:
     from topy.data import H8_K
-    H8 = load(fname)
+    H8 = load(fname, allow_pickle=True)
 
 # ============================================================
 # === Stiffness matrix of a cubic 8 node '18-beta' element ===
 # ============================================================
 fname = path.join(pth, 'H18B.K')
 try:
-    H18B = load(fname)
+    H18B = load(fname, allow_pickle=True)
 except IOError:
     from topy.data import H18B_K
-    H18B = load(fname)
+    H18B = load(fname, allow_pickle=True)
 
 # ==========================================================================
 # === Stiffness matrix for a hexahedron 8 node tri-linear 3D element for ===
@@ -118,9 +118,9 @@ except IOError:
 # ==========================================================================
 fname = path.join(pth, 'H8T.K')
 try:
-    H8T = load(fname)
+    H8T = load(fname, allow_pickle=True)
 except IOError:
     from topy.data import H8T_K
-    H8T = load(fname)
+    H8T = load(fname, allow_pickle=True)
 
 # EOF elements.py

--- a/topy/parser.py
+++ b/topy/parser.py
@@ -156,17 +156,17 @@ def _parse_dict(d):
 
     # Check for active elements:
     try:
-        d['ACTV_ELEM'] = _tpd2vec(d['ACTV_ELEM']) - 1
+        d['ACTV_ELEM'] = _tpd2vec(d['ACTV_ELEM'], int) - 1
     except KeyError:
-        d['ACTV_ELEM'] = _tpd2vec('')
+        d['ACTV_ELEM'] = _tpd2vec('', int)
     except AttributeError:
         pass
 
     # Check for passive elements:
     try:
-        d['PASV_ELEM'] = _tpd2vec(d['PASV_ELEM']) - 1
+        d['PASV_ELEM'] = _tpd2vec(d['PASV_ELEM'], int) - 1
     except KeyError:
-        d['PASV_ELEM'] = _tpd2vec('')
+        d['PASV_ELEM'] = _tpd2vec('', int)
     except AttributeError:
         pass
 
@@ -217,7 +217,7 @@ def _parse_dict(d):
 
     return d
 
-def _tpd2vec(seq):
+def _tpd2vec(seq, dtype=float):
     """
     Convert a tpd file string to a vector, return a NumPy array.
 
@@ -230,23 +230,23 @@ def _tpd2vec(seq):
         array([], dtype=float64)
 
     """
-    finalvec = np.array([], int)
+    finalvec = np.array([], dtype)
     for s in seq.split(';'):
         if s.count('|'):
-            values = [int(v) for v in s.split('|')]
+            values = [dtype(v) for v in s.split('|')]
             values[1] += 1
             vec = np.arange(*values)
         elif s.count('@'):
             value, num = s.split('@')
             try:
-                vec = np.ones(int(num)) * float(value)
+                vec = np.ones(int(num)) * dtype(value)
             except ValueError:
                 raise ValueError('%s is incorrectly specified' % seq)
         else:
             try:
-                vec = [float(s)]
+                vec = [dtype(s)]
             except ValueError:
-                vec = np.array([])
+                vec = np.array([], dtype)
         finalvec = np.append(finalvec, vec)
     return finalvec
 

--- a/topy/utils.py
+++ b/topy/utils.py
@@ -1,6 +1,7 @@
 """Common utilities."""
 import logging
 import sys
+import os
 
 def get_logger(name):
     # type: (str) -> logging.Logger
@@ -9,3 +10,11 @@ def get_logger(name):
     logger.addHandler(logging.StreamHandler(sys.stdout))
     logger.setLevel(logging.DEBUG)
     return logger
+
+
+def get_data_file(source_file_name):
+    # type: (str) -> (str)
+    """Return the data file path to store result."""
+    path = list(os.path.split(source_file_name))
+    path[-1] = path[-1].split('_')[0] + '.K'
+    return os.path.join(*path)


### PR DESCRIPTION
This pull request addresses the following issues:

- 99ec9f438d4f12de50d6b0e00e139a5c3a9d35f7: When generating stiffness matrix, an underscore in a folder name will result in a wrong data file name. This should solve #51
- a1b559b3474c2f538665328a437908db1a37f49d: Since version 1.16.3, NumPy requires explicitly allowing pickle due to security concerns.
- 0ce91c02fcc64e4c1564b2e4c4206661ad3fd962: When parsing a configuration file, a line with only plain numbers was inteperated as a floating point array (e.g. `1; 3; 8`). However, `PASV_ELEM` and `ACTV_ELEM` need to be integer array. I added a `dtype` parameter to `_tpd2vec`, forcing type conversion.

I didn't do an extensive testing. I tried the t-piece example and no regression is found.